### PR TITLE
feat: Implemented error logging

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	log "github.com/sirupsen/logrus"
 )
 
 type Error struct {
@@ -12,6 +13,7 @@ type Error struct {
 
 
 func writeError(w http.ResponseWriter, message string, code int) {
+	log.Error(code, ` Error: `, message)
 	resp := Error {
 		Code: code,
 		Message: message,


### PR DESCRIPTION
I realised that we do just want the error handler take a strung message, because that's sometimes what we want to be calling it with. Other times, if it's an error being used, the throwing code should handle converting it to a string.

This ain't javascript